### PR TITLE
fix silly typo

### DIFF
--- a/js/date_time.js
+++ b/js/date_time.js
@@ -9,7 +9,7 @@ function date_time(id) {
     date = new Date;
     year = date.getFullYear();
     month = date.getMonth();
-    months = new Array('January', 'February', 'March', 'April', 'May', 'June', 'Jully', 'August', 'September', 'October', 'November', 'December');
+    months = new Array('January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December');
     d = date.getDate();
     day = date.getDay();
     days = new Array('Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday');


### PR DESCRIPTION
"July" was misspelled as "Jully". This had me extremely confused for a second, but i later realized that it had to be the month July.

Best Regards
Team Natron